### PR TITLE
Default app auth redirect scheme

### DIFF
--- a/browser-sign-in/README.md
+++ b/browser-sign-in/README.md
@@ -67,6 +67,8 @@ export default {
 };
 ```
 
+If you set up your Okta Application with redirect URLs other than `com.sampleapplication:/`, update the value in `android/app/bundle.gradle` under defaultConfig > manifestPlaceholders > appAuthRedirectScheme.
+
 Now start the app server:
 
 ```bash

--- a/browser-sign-in/android/app/build.gradle
+++ b/browser-sign-in/android/app/build.gradle
@@ -134,7 +134,7 @@ android {
         versionCode 1
         versionName "1.0"
         manifestPlaceholders = [
-                appAuthRedirectScheme: 'com.okta.example'
+                appAuthRedirectScheme: 'com.sampleapplication'
         ]
     }
     splits {


### PR DESCRIPTION
Fixes #30 by updating the configured `appAuthRedirectScheme` to match the scheme that the README instructs you to create.

Also adds a note in the README for the need to update this value if you entered a different redirect URI in your Okta Application than the README instructed.