### PR TITLE
Update vulnarable dependencies for Android builds

### DIFF
--- a/browser-sign-in/android/forceVersions.gradle
+++ b/browser-sign-in/android/forceVersions.gradle
@@ -5,6 +5,8 @@ def forceVersions(ConfigurationContainer configurations) {
             force 'io.netty:netty-handler:4.1.118.Final' // from 4.1.93.Final
             force 'io.netty:netty-codec-http:4.1.118.Final' // from 4.1.93.Final
             force 'io.netty:netty-codec-http2:4.1.118.Final' // from 4.1.93.Final
+            force 'commons-codec:commons-codec:1.13' // from 1.10
+            force 'commons-io:commons-io:2.14.0' // from 2.6
         }
     }
 }

--- a/custom-sign-in/android/forceVersions.gradle
+++ b/custom-sign-in/android/forceVersions.gradle
@@ -5,6 +5,8 @@ def forceVersions(ConfigurationContainer configurations) {
             force 'io.netty:netty-handler:4.1.118.Final' // from 4.1.93.Final
             force 'io.netty:netty-codec-http:4.1.118.Final' // from 4.1.93.Final
             force 'io.netty:netty-codec-http2:4.1.118.Final' // from 4.1.93.Final
+            force 'commons-codec:commons-codec:1.13' // from 1.10
+            force 'commons-io:commons-io:2.14.0' // from 2.6
         }
     }
 }


### PR DESCRIPTION
Resolves:
- OKTA-651236
- OKTA-651238
- OKTA-651258
- OKTA-815486
- OKTA-816363
- OKTA-816377
- OKTA-816432

Tested with `yarn android` and found no regressions